### PR TITLE
feat(linea-monorepo): adjust the build process

### DIFF
--- a/.github/workflows/build-credible-besu-package.yaml
+++ b/.github/workflows/build-credible-besu-package.yaml
@@ -1,0 +1,39 @@
+name: Build Linea Besu Package with Credible plugin
+
+permissions:
+  contents: read
+  packages: write
+
+on:
+  push:
+    branches:
+      - main
+      - credible/*
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install packages
+        run: |
+          cd linea-besu-package && ./scripts/assemble-credible.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_TOKEN }}          
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: ./linea-besu-package/tmp
+          file: ./linea-besu-package/linea-besu/Dockerfile
+          tags: ghcr.io/${{ github.repository }}/linea-besu-package:${{ github.sha }}

--- a/linea-besu-package/scripts/assemble-credible.sh
+++ b/linea-besu-package/scripts/assemble-credible.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+source ./scripts/assemble-packages.sh
+
+cd ..
+
+# Required parameters
+OWNER="phylaxsystems"
+REPO="credible-layer-besu-plugin"
+GROUP_ID="net.phylax.credible"
+ARTIFACT_ID="credible-layer-besu-plugin"
+VERSION="0.1.0-d032df64"
+
+OUTPUT_LOC="./tmp/besu/plugins/$ARTIFACT_ID-$VERSION.jar"
+
+# Download using curl
+response=$(curl -s -w "%{http_code}" -L -H "Authorization: token $GITHUB_TOKEN" \
+     -H "Accept: application/octet-stream" \
+     "https://maven.pkg.github.com/$OWNER/$REPO/$GROUP_ID/$ARTIFACT_ID/$VERSION/$ARTIFACT_ID-$VERSION.jar" \
+     -o "$OUTPUT_LOC")
+
+http_code=${response: -3}
+
+if [ "$http_code" -eq 200 ]; then
+    echo "✅ Download successful!"
+else
+    echo "❌ Download failed with HTTP code: $http_code"
+    echo "💡 Check:"
+    echo "   - Token has 'read:packages' scope"
+    echo "   - You have access to the repository"
+    echo "   - Package coordinates are correct"
+    exit 1
+fi


### PR DESCRIPTION
# Description

This PR adds a separate build process for the linea-besu-package Dockerfile with the credible layer plugin.

The process extends the assemble-package script with downloading the credible-besu-plugin jar file from the repository packages. The Docker build remains the same by using `linea-besu-package/linea-besu/Dockerfile` with the context set to the temporary directory created by the assemble script.

**NOTE**: I couldn't use the phylaxsystems docker action because:
1. build context and Dockerfile aren't in the same directory structure (the action uses a fixed `context: .`)
2. the image can't contain capital letters, not an issue for us, but couldn't test locally (bug in the action)