### PR TITLE
feat(linea-monorepo): write credible e2e tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,9 @@
 [submodule "contracts/lib/forge-std"]
 	path = contracts/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "contracts/credible-layer"]
+	path = contracts/credible-layer
+	url = git@github.com:phylaxsystems/credible-layer-contracts.git
+[submodule "contracts/lib/credible-std"]
+	path = contracts/lib/credible-std
+	url = https://github.com/phylaxsystems/credible-std

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "contracts/lib/forge-std"]
 	path = contracts/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-[submodule "contracts/credible-layer"]
-	path = contracts/credible-layer
-	url = git@github.com:phylaxsystems/credible-layer-contracts.git
 [submodule "contracts/lib/credible-std"]
 	path = contracts/lib/credible-std
 	url = https://github.com/phylaxsystems/credible-std

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,14 @@ stop_pid:
 start-credible: ## Start environment with Credible Layer sidecar
 	make start-env COMPOSE_PROFILES=l1,l2,credible COMPOSE_FILE=docker/compose-credible-sidecar.yml
 
+start-credible-tracing-ci: ## Start environment with Credible Layer sidecar configured for CI
+	make start-env COMPOSE_PROFILES=l1,l2,credible COMPOSE_FILE=docker/compose-credible-tracing-ci-extension.yml LINEA_COORDINATOR_DISABLE_TYPE2_STATE_PROOF_PROVIDER=false LINEA_COORDINATOR_SIGNER_TYPE=web3signer
+
 stop-credible: ## Stop Credible Layer sidecar
 	docker compose -f docker/compose-credible-sidecar.yml --profile credible --profile l1 --profile l2 stop
+
+stop-credible-tracing-ci: ## Stop Credible Layer sidecar configured for CI
+	docker compose -f docker/compose-credible-tracing-ci-extension.yml --profile credible --profile l1 --profile l2 stop
 
 clean-credible: ## Clean Credible Layer sidecar and volumes
 	docker compose -f docker/compose-credible-sidecar.yml --profile credible --profile l1 --profile l2 down || true;
@@ -121,5 +127,4 @@ test-credible: ## Test Credible Layer sidecar endpoints
 		http://localhost:9546 | jq . || echo "RPC endpoint not available"
 	@echo "\nMetrics endpoint (if configured):"
 	@curl -s http://localhost:9000/metrics | head -n 5 || echo "Metrics not available"
-
 

--- a/contracts/src/credible/SimpleCounterAssertion.sol
+++ b/contracts/src/credible/SimpleCounterAssertion.sol
@@ -5,6 +5,7 @@ import {Assertion} from "credible-std/Assertion.sol";
 
 contract Counter {
     uint256 public number;
+    address public owner = address(0x1B9AbEeC3215D8AdE8a33607f2cF0f4F60e5F0D0);
 
     function increment() public {
         number++;
@@ -14,10 +15,15 @@ contract Counter {
 contract SimpleCounterAssertion is Assertion {
     event RunningAssertion(uint256 count);
 
+    Counter public immutable counter;
+
+    constructor(address counterAddress) {
+        require(counterAddress != address(0), "Counter address cannot be zero");
+        counter = Counter(counterAddress);
+    }
+
     function assertCount() public {
-        // FIXME: hardcoded address of the counter contract from above, needs changing
-        // generated with cast compute-address 0x1B9AbEeC3215D8AdE8a33607f2cF0f4F60e5F0D0 --nonce 0
-        uint256 count = Counter(0x729409FAD88CafdA895E41f9ED00Ef4094F8d130).number();
+        uint256 count = counter.number();
         emit RunningAssertion(count);
         if (count > 1) {
             revert("Counter cannot be greater than 1");

--- a/contracts/src/credible/SimpleCounterAssertion.sol
+++ b/contracts/src/credible/SimpleCounterAssertion.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.11;
+
+import {Assertion} from "credible-std/Assertion.sol";
+
+contract Counter {
+    uint256 public number;
+
+    function increment() public {
+        number++;
+    }
+}
+
+contract SimpleCounterAssertion is Assertion {
+    event RunningAssertion(uint256 count);
+
+    function assertCount() public {
+        // FIXME: hardcoded address of the counter contract from above, needs changing
+        // generated with cast compute-address 0x1B9AbEeC3215D8AdE8a33607f2cF0f4F60e5F0D0 --nonce 0
+        uint256 count = Counter(0x729409FAD88CafdA895E41f9ED00Ef4094F8d130).number();
+        emit RunningAssertion(count);
+        if (count > 1) {
+            revert("Counter cannot be greater than 1");
+        }
+    }
+
+    function triggers() external view override {
+        registerCallTrigger(this.assertCount.selector);
+    }
+}

--- a/docker/compose-credible-sidecar.yml
+++ b/docker/compose-credible-sidecar.yml
@@ -65,7 +65,7 @@ services:
       # RPC server (currently only responds to "ping" method)
       - "9546:9546"
       # Metrics port (if configured)
-      - "9000:9000"
+      - "9013:9000"
     restart: unless-stopped
     networks:
       linea:

--- a/docker/compose-credible-tracing-ci-extension.yml
+++ b/docker/compose-credible-tracing-ci-extension.yml
@@ -1,0 +1,28 @@
+include:
+  - compose-credible-sidecar.yml
+
+services:
+  web3signer:
+    extends:
+      file: compose-spec-l2-services.yml
+      service: web3signer
+
+  l2-node-besu:
+    extends:
+      file: compose-spec-l2-services.yml
+      service: l2-node-besu
+
+  shomei-frontend:
+    extends:
+      file: compose-spec-l2-services.yml
+      service: shomei-frontend
+
+  postman:
+    extends:
+      file: compose-spec-l2-services.yml
+      service: postman
+
+  transaction-exclusion-api:
+    extends:
+      file: compose-spec-l2-services.yml
+      service: transaction-exclusion-api

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -74,7 +74,7 @@ services:
       - ./config/linea-besu-sequencer/key:/var/lib/besu/key:ro
       - ./config/linea-besu-sequencer/log4j.xml:/var/lib/besu/log4j.xml:ro
       - ./config/linea-besu-sequencer/tls-files:/var/lib/besu/tls-files/
-      - ../config/common/traces-limits-v2.toml:/var/lib/besu/traces-limits.toml:ro
+      - ../config/common/traces-limits-limitless.toml:/var/lib/besu/traces-limits.toml:ro
       - ./config/l2-genesis-initialization:/initialization/:ro
     networks:
       l1network:

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -39,7 +39,7 @@ services:
   sequencer:
     hostname: sequencer
     container_name: sequencer
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc10-20250923173528-1a4fb69}
+    image: penumbra23/linea-besu-package:ad017736-credible-f23a3d4b
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       l2-genesis-initialization:

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -150,7 +150,7 @@ services:
       - ./config/l2-node-besu/l2-node-besu-config.toml:/var/lib/besu/l2-node-besu.config.toml:ro
       - ./config/linea-besu-sequencer/deny-list.txt:/var/lib/besu/deny-list.txt:ro
       - ./config/l2-node-besu/log4j.xml:/var/lib/besu/log4j.xml:ro
-      - ../config/common/traces-limits-v2.toml:/var/lib/besu/traces-limits.toml:ro
+      - ../config/common/traces-limits-limitless.toml:/var/lib/besu/traces-limits.toml:ro
       - ./config/l2-genesis-initialization:/initialization/:ro
       - ../tmp/local/:/data/:rw
     networks:
@@ -194,7 +194,7 @@ services:
       - ./config/l2-node-besu/l2-node-besu-config.toml:/var/lib/besu/l2-node-besu.config.toml:ro
       - ./config/linea-besu-sequencer/deny-list.txt:/var/lib/besu/deny-list.txt:ro
       - ./config/l2-node-besu/log4j.xml:/var/lib/besu/log4j.xml:ro
-      - ../config/common/traces-limits-v2.toml:/var/lib/besu/traces-limits.toml:ro
+      - ../config/common/traces-limits-limitless.toml:/var/lib/besu/traces-limits.toml:ro
       - ./config/l2-genesis-initialization:/initialization/:ro
       - ../tmp/local/:/data/:rw
     networks:

--- a/docker/config/l2-genesis-initialization/genesis-besu.json.template
+++ b/docker/config/l2-genesis-initialization/genesis-besu.json.template
@@ -12,17 +12,15 @@
     "istanbulBlock": 0,
     "berlinBlock": 0,
     "londonBlock": 0,
-    "terminalTotalDifficulty": 8,
-    "shanghaiTime": %SHANGHAI_TIME%,
-    "cancunTime": %CANCUN_TIME%,
+    "terminalTotalDifficulty": 1,
+    "terminalTotalDifficultyPassed": true, 
+    "shanghaiTime": 0,
+    "cancunTime": 0,
+    "mergeNetsplitBlock": 0,
+    "ethash": {},
     "depositContractAddress": "0x3a69eD7FA6f6CA1dB2649327c4A2E666130823bE",
     "withdrawalRequestContractAddress": "0x3a69eD7FA6f6CA1dB2649327c4A2E666130823bE",
-    "consolidationRequestContractAddress": "0x9AFC00F4CEaadb97A3822FCA2225FaD78839FBde",
-    "clique": {
-      "createemptyblocks": %CREATE_EMPTY_BLOCKS%,
-      "blockperiodseconds": 1,
-      "epochlength": 1
-    }
+    "consolidationRequestContractAddress": "0x9AFC00F4CEaadb97A3822FCA2225FaD78839FBde"
   },
   "coinbase": "0x0000000000000000000000000000000000000000",
   "difficulty": "0x1",

--- a/docker/config/l2-genesis-initialization/genesis-maru.json.template
+++ b/docker/config/l2-genesis-initialization/genesis-maru.json.template
@@ -2,21 +2,6 @@
   "chainId": 1337,
   "config": {
     "0": {
-      "type": "difficultyAwareQbft",
-      "blockTimeSeconds": 1,
-      "postTtdConfig": {
-        "validatorSet": ["0x083e11f14b68d5ebeb4be3e3e0237ebbc5675ab5"],
-        "elFork": "Paris"
-      },
-      "terminalTotalDifficulty": 8
-    },
-    "%SHANGHAI_TIME%": {
-      "type": "qbft",
-      "validatorSet": ["0x083e11f14b68d5ebeb4be3e3e0237ebbc5675ab5"],
-      "blockTimeSeconds": 1,
-      "elFork": "Shanghai"
-    },
-    "%CANCUN_TIME%": {
       "type": "qbft",
       "validatorSet": ["0x083e11f14b68d5ebeb4be3e3e0237ebbc5675ab5"],
       "blockTimeSeconds": 1,

--- a/docker/config/l2-node-besu/l2-node-besu-config.toml
+++ b/docker/config/l2-node-besu/l2-node-besu-config.toml
@@ -58,7 +58,7 @@ plugin-linea-estimate-gas-min-margin="1.2"
 plugin-linea-bundles-forward-urls=["http://sequencer:8545"]
 plugin-linea-bundles-forward-retry-delay=1000
 plugin-linea-bundles-forward-timeout=5000
-plugin-linea-limitless-enabled=false
+plugin-linea-limitless-enabled=true
 
 bonsai-limit-trie-logs-enabled=false
 bonsai-historical-block-limit=1024

--- a/docker/config/linea-besu-sequencer/sequencer.config.toml
+++ b/docker/config/linea-besu-sequencer/sequencer.config.toml
@@ -20,7 +20,7 @@ engine-jwt-disabled=true
 rpc-http-enabled=true
 rpc-http-host="0.0.0.0"
 rpc-http-port=8545
-rpc-http-api=["ADMIN","DEBUG","NET","ETH","ENGINE","CLIQUE","MINER","WEB3","TRACE","LINEA"]
+rpc-http-api=["ADMIN","DEBUG","NET","ETH","ENGINE","MINER","WEB3","TRACE","LINEA", "TXPOOL"]
 rpc-http-cors-origins=["*"]
 rpc-http-max-active-connections=20000
 
@@ -28,7 +28,7 @@ rpc-http-max-active-connections=20000
 rpc-ws-enabled=true
 rpc-ws-host="0.0.0.0"
 rpc-ws-port=8546
-rpc-ws-api=["ADMIN","DEBUG","NET","ETH","CLIQUE","MINER","WEB3","TRACE","LINEA"]
+rpc-ws-api=["ADMIN","DEBUG","NET","ETH","MINER","WEB3","TRACE","LINEA"]
 rpc-ws-max-active-connections=200
 
 # graphql
@@ -44,7 +44,7 @@ tx-pool-no-local-priority=false
 api-gas-and-priority-fee-limiting-enabled=false
 api-gas-and-priority-fee-lower-bound-coefficient=120
 api-gas-and-priority-fee-upper-bound-coefficient=300
-poa-block-txs-selection-max-time=1000
+#poa-block-txs-selection-max-time=1000
 
 # plugins
 plugins=["LineaEstimateGasEndpointPlugin","LineaL1FinalizationTagUpdaterPlugin","LineaExtraDataPlugin","LineaTransactionPoolValidatorPlugin","LineaBundleEndpointsPlugin","LineaSetExtraDataEndpointPlugin","LineaTransactionSelectorPlugin"]

--- a/docker/config/linea-besu-sequencer/sequencer.config.toml
+++ b/docker/config/linea-besu-sequencer/sequencer.config.toml
@@ -47,7 +47,7 @@ api-gas-and-priority-fee-upper-bound-coefficient=300
 #poa-block-txs-selection-max-time=1000
 
 # plugins
-plugins=["LineaEstimateGasEndpointPlugin","LineaL1FinalizationTagUpdaterPlugin","LineaExtraDataPlugin","LineaTransactionPoolValidatorPlugin","LineaBundleEndpointsPlugin","LineaSetExtraDataEndpointPlugin","LineaTransactionSelectorPlugin"]
+plugins=["LineaEstimateGasEndpointPlugin","LineaL1FinalizationTagUpdaterPlugin","LineaExtraDataPlugin","LineaTransactionPoolValidatorPlugin","LineaBundleEndpointsPlugin","LineaSetExtraDataEndpointPlugin","LineaTransactionSelectorPlugin","CredibleLayerPlugin"]
 plugin-linea-module-limit-file-path="/var/lib/besu/traces-limits.toml"
 plugin-linea-deny-list-path="/var/lib/besu/deny-list.txt"
 plugin-linea-estimate-gas-compatibility-mode-enabled=false
@@ -68,6 +68,8 @@ plugin-linea-variable-gas-cost-wei=1000000000
 plugin-linea-extra-data-set-min-gas-price-enabled=false
 plugin-linea-estimate-gas-min-margin="1.2"
 plugin-linea-limitless-enabled=true
+plugin-credible-sidecar-rpc-endpoints=["http://credible-sidecar:9546/tx"]
+plugin-credible-sidecar-rpc-fallback-endpoints=["http://credible-sidecar-2:9546/tx"]
 strict-tx-replay-protection-enabled=false
 
 # should uncomment only when the linea-sequencer plugin supports liveness 

--- a/docker/config/linea-besu-sequencer/sequencer.config.toml
+++ b/docker/config/linea-besu-sequencer/sequencer.config.toml
@@ -67,7 +67,7 @@ plugin-linea-fixed-gas-cost-wei=30000000
 plugin-linea-variable-gas-cost-wei=1000000000
 plugin-linea-extra-data-set-min-gas-price-enabled=false
 plugin-linea-estimate-gas-min-margin="1.2"
-plugin-linea-limitless-enabled=false
+plugin-linea-limitless-enabled=true
 strict-tx-replay-protection-enabled=false
 
 # should uncomment only when the linea-sequencer plugin supports liveness 

--- a/docker/config/maru/sequencer.config.toml
+++ b/docker/config/maru/sequencer.config.toml
@@ -1,4 +1,4 @@
-allow-empty-blocks = false
+allow-empty-blocks = true
 
 [linea]
 contract-address = "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,7 +2,8 @@
 ## Setup
 Run `pnpm install` to setup typechain
 
-Run `make start-env-with-tracing-v2-ci` from root directory to spin up local environment
+Run `make start-env-with-tracing-v2-ci` from root directory to spin up local environment.
+For credible layer e2e tests start wirh `make start-credible-tracing-ci`.
 
 
 ## Run tests

--- a/e2e/src/common/constants.ts
+++ b/e2e/src/common/constants.ts
@@ -7,6 +7,9 @@ export const OPERATOR_ROLE = "0x97667070c54ef182b0f5858b034beac1b6f3089aa2d3188b
 export const VERIFIER_SETTER_ROLE = "0x32937fd5162e282df7e9a14a5073a2425321c7966eaf70ed6c838a1006d84c4c";
 export const MESSAGE_SENT_EVENT_SIGNATURE = "0xe856c2b8bd4eb0027ce32eeaf595c21b0b6b4644b326e5b7bd80a1cf8db72e6c";
 
+// pcl unit test consts
+export const STATE_ORACLE_ADDRESS = "0x6dD3f12ce435f69DCeDA7e31605C02Bb5422597b";
+
 export const HASH_ZERO = ethers.ZeroHash;
 export const EMPTY_CONTRACT_CODE = "0x";
 export const TRANSACTION_CALLDATA_LIMIT = 30_000;

--- a/e2e/src/common/utils.ts
+++ b/e2e/src/common/utils.ts
@@ -11,7 +11,7 @@ import {
   toBeHex,
 } from "ethers";
 import path from "path";
-import { exec } from "child_process";
+import { exec, spawn } from "child_process";
 import { L2MessageServiceV1 as L2MessageService, TokenBridgeV1_1 as TokenBridge, LineaRollupV6 } from "../typechain";
 import { PayableOverrides, TypedContractEvent, TypedDeferredTopicFilter, TypedEventLog } from "../typechain/common";
 import { MessageEvent, SendMessageArgs } from "./types";
@@ -405,6 +405,178 @@ export class TransactionExclusionClient {
     };
     const response = await fetch(this.endpoint, request);
     return await response.json();
+  }
+}
+
+export class AssertionDaError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "AssertionDaError";
+  }
+}
+
+type PclSpawnOptions = {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+};
+
+export class AssertionDaClient {
+  private readonly endpoint?: URL;
+  private readonly pclPath: string;
+
+  public constructor(endpoint?: URL, pclPath: string = "pcl") {
+    this.endpoint = endpoint;
+    this.pclPath = pclPath;
+  }
+
+  public async storeAssertion(
+    assertionName: string,
+    constructorArgs: string[],
+    options: PclSpawnOptions = {},
+  ): Promise<{ assertionId: string; signature: string }> {
+    if (!this.endpoint) {
+      throw new AssertionDaError("Endpoint is required to store assertions");
+    }
+
+    const pclArgs = [
+      "--json",
+      "store",
+      "-u",
+      this.endpoint.toString(),
+      "--root",
+      "solidity",
+      assertionName,
+      ...constructorArgs,
+    ];
+
+    const stdout = await this.runPcl(pclArgs, options);
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch (err) {
+      throw new AssertionDaError(`Failed to parse PCL output: ${(err as Error).message}`);
+    }
+
+    if (typeof parsed !== "object" || parsed === null) {
+      throw new AssertionDaError("Unexpected response type from PCL");
+    }
+
+    const maybeResult = parsed as Record<string, unknown>;
+
+    if ("error" in maybeResult) {
+      throw new AssertionDaError(`Error storing assertion: ${JSON.stringify(maybeResult.error)}`);
+    }
+
+    const assertionId = maybeResult.assertion_id;
+    const signature = maybeResult.signature;
+
+    if (typeof assertionId !== "string" || typeof signature !== "string") {
+      throw new AssertionDaError(`Unexpected response from PCL: ${JSON.stringify(maybeResult)}`);
+    }
+
+    return { assertionId, signature };
+  }
+
+  public async getAssertion(
+    assertionId: string,
+  ): Promise<{ bytecode?: string; signature?: string; soliditySource?: string }> {
+    const result = await this.sendRpcRequest<Record<string, unknown>>("da_get_assertion", [assertionId]);
+
+    return {
+      bytecode: typeof result.bytecode === "string" ? result.bytecode : undefined,
+      signature: typeof result.signature === "string" ? result.signature : undefined,
+      soliditySource: typeof result.solidity_source === "string" ? result.solidity_source : undefined,
+    };
+  }
+
+  public async sendRpcRequest<T = unknown>(
+    method: string,
+    params: unknown[] | Record<string, unknown> = [],
+  ): Promise<T> {
+    if (!this.endpoint) {
+      throw new AssertionDaError("Endpoint is required for RPC requests");
+    }
+
+    const request = {
+      method: "post",
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method,
+        params,
+        id: generateRandomInt(),
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+
+    const response = await fetch(this.endpoint.toString(), request);
+    const responseJson = await response.json();
+
+    if ("error" in responseJson) {
+      throw new AssertionDaError(
+        typeof responseJson.error === "object" ? JSON.stringify(responseJson.error) : String(responseJson.error),
+      );
+    }
+
+    if (!("result" in responseJson)) {
+      throw new AssertionDaError(`Unexpected response format: ${JSON.stringify(responseJson)}`);
+    }
+
+    return responseJson.result as T;
+  }
+
+  private async runPcl(args: string[], options: PclSpawnOptions): Promise<string> {
+    return await new Promise((resolve, reject) => {
+      const child = spawn(this.pclPath, args, {
+        cwd: options.cwd,
+        env: { ...process.env, ...options.env },
+      });
+
+      let stdout = "";
+      let stderr = "";
+
+      child.stdout?.on("data", (data: Buffer) => {
+        stdout += data.toString();
+      });
+
+      child.stderr?.on("data", (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      const timeout = options.timeoutMs
+        ? setTimeout(() => {
+            child.kill();
+            reject(new AssertionDaError(`PCL command timed out after ${options.timeoutMs}ms`));
+          }, options.timeoutMs)
+        : undefined;
+
+      child.on("error", (error) => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        reject(new AssertionDaError(`Failed to execute PCL command: ${error.message}`));
+      });
+
+      child.on("close", (code) => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+
+        if (code !== 0) {
+          reject(new AssertionDaError(`PCL command exited with code ${code}. stderr=${stderr || "<empty>"}`));
+          return;
+        }
+
+        if (stderr.trim().length > 0) {
+          logger.warn(`PCL command emitted stderr: ${stderr}`);
+        }
+
+        resolve(stdout.trim());
+      });
+    });
   }
 }
 

--- a/e2e/src/common/utils.ts
+++ b/e2e/src/common/utils.ts
@@ -422,7 +422,7 @@ type PclSpawnOptions = {
 };
 
 export class AssertionDaClient {
-  private readonly endpoint?: URL;
+  private readonly endpoint: URL | undefined;
   private readonly pclPath: string;
 
   public constructor(endpoint?: URL, pclPath: string = "pcl") {
@@ -435,7 +435,8 @@ export class AssertionDaClient {
     constructorArgs: string[],
     options: PclSpawnOptions = {},
   ): Promise<{ assertionId: string; signature: string }> {
-    if (!this.endpoint) {
+    const endpoint = this.endpoint;
+    if (!endpoint) {
       throw new AssertionDaError("Endpoint is required to store assertions");
     }
 
@@ -443,7 +444,7 @@ export class AssertionDaClient {
       "--json",
       "store",
       "-u",
-      this.endpoint.toString(),
+      endpoint.toString(),
       "--root",
       "solidity",
       assertionName,
@@ -484,18 +485,26 @@ export class AssertionDaClient {
   ): Promise<{ bytecode?: string; signature?: string; soliditySource?: string }> {
     const result = await this.sendRpcRequest<Record<string, unknown>>("da_get_assertion", [assertionId]);
 
-    return {
-      bytecode: typeof result.bytecode === "string" ? result.bytecode : undefined,
-      signature: typeof result.signature === "string" ? result.signature : undefined,
-      soliditySource: typeof result.solidity_source === "string" ? result.solidity_source : undefined,
-    };
+    const response: { bytecode?: string; signature?: string; soliditySource?: string } = {};
+    if (typeof result.bytecode === "string") {
+      response.bytecode = result.bytecode;
+    }
+    if (typeof result.signature === "string") {
+      response.signature = result.signature;
+    }
+    if (typeof result.solidity_source === "string") {
+      response.soliditySource = result.solidity_source;
+    }
+
+    return response;
   }
 
   public async sendRpcRequest<T = unknown>(
     method: string,
     params: unknown[] | Record<string, unknown> = [],
   ): Promise<T> {
-    if (!this.endpoint) {
+    const endpoint = this.endpoint;
+    if (!endpoint) {
       throw new AssertionDaError("Endpoint is required for RPC requests");
     }
 
@@ -512,7 +521,7 @@ export class AssertionDaClient {
       },
     };
 
-    const response = await fetch(this.endpoint.toString(), request);
+    const response = await fetch(endpoint.toString(), request);
     const responseJson = await response.json();
 
     if ("error" in responseJson) {

--- a/e2e/src/common/utils.ts
+++ b/e2e/src/common/utils.ts
@@ -430,6 +430,26 @@ export class AssertionDaClient {
     this.pclPath = pclPath;
   }
 
+  public async submitAssertionBytecode(bytecode: string): Promise<{ assertionId: string; signature: string }> {
+    const endpoint = this.endpoint;
+    if (!endpoint) {
+      throw new AssertionDaError("Endpoint is required to submit assertions");
+    }
+
+    const prefixedBytecode = bytecode.startsWith("0x") ? bytecode : `0x${bytecode}`;
+
+    const result = await this.sendRpcRequest<Record<string, unknown>>("da_submit_assertion", [prefixedBytecode]);
+
+    const assertionId = result.id;
+    const signature = result.prover_signature ?? result.signature;
+
+    if (typeof assertionId !== "string" || typeof signature !== "string") {
+      throw new AssertionDaError(`Unexpected response from assertion DA: ${JSON.stringify(result)}`);
+    }
+
+    return { assertionId, signature };
+  }
+
   public async storeAssertion(
     assertionName: string,
     constructorArgs: string[],
@@ -480,12 +500,22 @@ export class AssertionDaClient {
     return { assertionId, signature };
   }
 
-  public async getAssertion(
-    assertionId: string,
-  ): Promise<{ bytecode?: string; signature?: string; soliditySource?: string }> {
+  public async getAssertion(assertionId: string): Promise<{
+    bytecode?: string;
+    signature?: string;
+    soliditySource?: string;
+    encodedConstructorArgs?: string;
+    constructorAbiSignature?: string;
+  }> {
     const result = await this.sendRpcRequest<Record<string, unknown>>("da_get_assertion", [assertionId]);
 
-    const response: { bytecode?: string; signature?: string; soliditySource?: string } = {};
+    const response: {
+      bytecode?: string;
+      signature?: string;
+      soliditySource?: string;
+      encodedConstructorArgs?: string;
+      constructorAbiSignature?: string;
+    } = {};
     if (typeof result.bytecode === "string") {
       response.bytecode = result.bytecode;
     }
@@ -494,6 +524,12 @@ export class AssertionDaClient {
     }
     if (typeof result.solidity_source === "string") {
       response.soliditySource = result.solidity_source;
+    }
+    if (typeof result.encoded_constructor_args === "string") {
+      response.encodedConstructorArgs = result.encoded_constructor_args;
+    }
+    if (typeof result.constructor_abi_signature === "string") {
+      response.constructorAbiSignature = result.constructor_abi_signature;
     }
 
     return response;

--- a/e2e/src/config/tests-config/environments/local.ts
+++ b/e2e/src/config/tests-config/environments/local.ts
@@ -11,6 +11,7 @@ const SHOMEI_ENDPOINT = new URL("http://localhost:8998");
 const SHOMEI_FRONTEND_ENDPOINT = new URL("http://localhost:8889");
 const SEQUENCER_ENDPOINT = new URL("http://localhost:8545");
 const TRANSACTION_EXCLUSION_ENDPOINT = new URL("http://localhost:8082");
+const ASSERTION_DA_ENDPOINT = new URL("http://localhost:5001");
 
 const config: Config = {
   L1: {
@@ -52,6 +53,7 @@ const config: Config = {
     shomeiFrontendEndpoint: SHOMEI_FRONTEND_ENDPOINT,
     sequencerEndpoint: SEQUENCER_ENDPOINT,
     transactionExclusionEndpoint: TRANSACTION_EXCLUSION_ENDPOINT,
+    assertionDaEndpoint: ASSERTION_DA_ENDPOINT,
   },
 };
 

--- a/e2e/src/config/tests-config/setup.ts
+++ b/e2e/src/config/tests-config/setup.ts
@@ -99,6 +99,13 @@ export default class TestSetup {
     return this.config.L2.transactionExclusionEndpoint;
   }
 
+  public getAssertionDaEndpoint(): URL | undefined {
+    if (!this.isLocalL2Config(this.config.L2)) {
+      return undefined;
+    }
+    return this.config.L2.assertionDaEndpoint;
+  }
+
   public getLineaRollupContract(signer?: AbstractSigner): LineaRollupV6 {
     const lineaRollup: LineaRollupV6 = LineaRollupV6__factory.connect(
       this.config.L1.lineaRollupAddress,
@@ -273,7 +280,8 @@ export default class TestSetup {
       (config as LocalL2Config).sequencerEndpoint !== undefined &&
       (config as LocalL2Config).shomeiEndpoint !== undefined &&
       (config as LocalL2Config).shomeiFrontendEndpoint !== undefined &&
-      (config as LocalL2Config).transactionExclusionEndpoint !== undefined
+      (config as LocalL2Config).transactionExclusionEndpoint !== undefined &&
+      (config as LocalL2Config).assertionDaEndpoint !== undefined
     );
   }
 }

--- a/e2e/src/config/tests-config/types.ts
+++ b/e2e/src/config/tests-config/types.ts
@@ -27,6 +27,7 @@ export type BaseL2Config = BaseConfig & {
   shomeiFrontendEndpoint?: URL;
   sequencerEndpoint?: URL;
   transactionExclusionEndpoint?: URL;
+  assertionDaEndpoint?: URL;
 };
 
 export type LocalL2Config = BaseL2Config & {
@@ -35,6 +36,7 @@ export type LocalL2Config = BaseL2Config & {
   shomeiFrontendEndpoint: URL;
   sequencerEndpoint: URL;
   transactionExclusionEndpoint: URL;
+  assertionDaEndpoint: URL;
 };
 
 export type DevL2Config = BaseL2Config;

--- a/e2e/src/credible-layer.spec.ts
+++ b/e2e/src/credible-layer.spec.ts
@@ -145,6 +145,9 @@ describeCredible("Credible layer e2e test suite", () => {
       typeof CounterArtifact.bytecode === "string" ? CounterArtifact.bytecode : CounterArtifact.bytecode.object;
 
     const counterFactory = new ethers.ContractFactory(CounterArtifact.abi, counterBytecode, deployer);
+    logger.info(
+      `Counter artifact info. bytecodeBytes=${counterBytecode ? (counterBytecode.length - 2) / 2 : 0} abiEntries=${CounterArtifact.abi.length}`,
+    );
 
     const formatNullableBigInt = (value: bigint | null | undefined) => (value == null ? "null" : value.toString());
 
@@ -158,11 +161,22 @@ describeCredible("Credible layer e2e test suite", () => {
       counterDeployOverrides.gasPrice = feeData.gasPrice;
     }
 
-    const deployTx = counterFactory.getDeployTransaction();
+    const deployTx = await counterFactory.getDeployTransaction();
+    const deployDataBytes = deployTx.data ? (deployTx.data.length - 2) / 2 : 0;
+    logger.info(
+      `Prepared Counter deployment transaction request. to=${deployTx.to ?? "<constructor>"} dataBytes=${deployDataBytes} value=${formatNullableBigInt(deployTx.value)}`,
+    );
+    if (deployDataBytes === 0) {
+      logger.error(
+        "Counter deployment transaction missing init code bytes; the artifact bytecode may be empty or not wired correctly.",
+      );
+    }
     const estimationRequest: TransactionRequest = {
-      ...deployTx,
       ...counterDeployOverrides,
       from: deployerAddress,
+      to: deployTx.to,
+      data: deployTx.data,
+      value: deployTx.value,
     };
     const estimatedGas = await deployer.estimateGas(estimationRequest);
     const bufferedGas = (estimatedGas * 12n) / 10n;
@@ -173,6 +187,11 @@ describeCredible("Credible layer e2e test suite", () => {
       : bufferedGas;
 
     const counterConstructorGas = await l2Provider.estimateGas(estimationRequest);
+    logger.info(
+      `Counter gas estimation. rawEstimate=${formatNullableBigInt(counterConstructorGas)} buffered=${formatNullableBigInt(
+        (counterConstructorGas * 12n) / 10n,
+      )}`,
+    );
     const deploymentNonceBefore = await l2Provider.getTransactionCount(deployerAddress, "latest");
     const counterDeployTx = await deployer.sendTransaction({
       ...estimationRequest,
@@ -188,8 +207,20 @@ describeCredible("Credible layer e2e test suite", () => {
     expect(deploymentNonce).toBe(deploymentNonceBefore);
 
     const counterAddress = deploymentReceipt?.contractAddress ?? ethers.ZeroAddress;
+    const confirmations =
+      typeof deploymentReceipt?.confirmations === "function"
+        ? await deploymentReceipt.confirmations()
+        : deploymentReceipt?.confirmations ?? "null";
     logger.info(
-      `Counter deployment receipt. txHash=${counterDeployTx.hash} status=${deploymentReceipt?.status ?? "null"} contractAddress=${counterAddress} blockNumber=${deploymentReceipt?.blockNumber ?? "null"} confirmations=${deploymentReceipt?.confirmations ?? "null"} gasUsed=${formatNullableBigInt(deploymentReceipt?.gasUsed)} cumulativeGasUsed=${formatNullableBigInt(deploymentReceipt?.cumulativeGasUsed)} effectiveGasPrice=${formatNullableBigInt(deploymentReceipt?.effectiveGasPrice)} type=${deploymentReceipt?.type ?? "null"}`,
+      `Counter deployment receipt. txHash=${counterDeployTx.hash} status=${deploymentReceipt?.status ?? "null"} contractAddress=${counterAddress} blockNumber=${
+        deploymentReceipt?.blockNumber ?? "null"
+      } confirmations=${confirmations} gasUsed=${formatNullableBigInt(
+        deploymentReceipt?.gasUsed,
+      )} cumulativeGasUsed=${formatNullableBigInt(
+        deploymentReceipt?.cumulativeGasUsed,
+      )} effectiveGasPrice=${formatNullableBigInt(deploymentReceipt?.effectiveGasPrice)} type=${
+        deploymentReceipt?.type ?? "null"
+      }`,
     );
     if (counterAddress === ethers.ZeroAddress) {
       logger.error(
@@ -198,10 +229,52 @@ describeCredible("Credible layer e2e test suite", () => {
     }
     expect(counterAddress).not.toEqual(ethers.ZeroAddress);
 
+    const txOnChain = await l2Provider.getTransaction(counterDeployTx.hash);
+    logger.info(
+      `Counter deployment transaction on-chain. blockNumber=${txOnChain?.blockNumber ?? "null"} gasLimit=${formatNullableBigInt(
+        txOnChain?.gasLimit,
+      )} gasPrice=${formatNullableBigInt(txOnChain?.gasPrice)} maxFeePerGas=${formatNullableBigInt(
+        txOnChain?.maxFeePerGas,
+      )} maxPriorityFeePerGas=${formatNullableBigInt(txOnChain?.maxPriorityFeePerGas)} dataBytes=${
+        txOnChain?.data ? (txOnChain.data.length - 2) / 2 : 0
+      } value=${formatNullableBigInt(txOnChain?.value)}`,
+    );
+
+    if (deploymentReceipt) {
+      const receiptLogSummary = (deploymentReceipt.logs ?? []).map((log) => ({
+        index: log.index,
+        address: log.address,
+        topics: log.topics,
+        dataBytes: (log.data.length - 2) / 2,
+      }));
+      logger.info(
+        `Counter deployment receipt logs summary. logsCount=${receiptLogSummary.length} details=${JSON.stringify(receiptLogSummary)}`,
+      );
+
+      const deploymentBlock = deploymentReceipt.blockNumber
+        ? await l2Provider.getBlock(deploymentReceipt.blockNumber)
+        : null;
+      if (deploymentBlock) {
+        logger.info(
+          `Counter deployment block info. blockNumber=${deploymentBlock.number} hash=${deploymentBlock.hash} parentHash=${deploymentBlock.parentHash} stateRoot=${deploymentBlock.stateRoot} txCount=${deploymentBlock.transactions.length}`,
+        );
+      }
+    }
+
     logger.info(
       `Counter deployed for Credible Layer tests. address=${counterAddress} nonce=${deploymentNonce} deployer=${deployerAddress} gasUsed=${deploymentReceipt?.gasUsed}`,
     );
     if (counterAddress !== ethers.ZeroAddress) {
+      const counterCodeAtBlock = deploymentReceipt?.blockNumber
+        ? await l2Provider.getCode(counterAddress, deploymentReceipt.blockNumber)
+        : null;
+      if (counterCodeAtBlock != null) {
+        logger.info(
+          `Counter contract code at deployment block. blockNumber=${deploymentReceipt?.blockNumber ?? "null"} byteLength=${
+            counterCodeAtBlock === "0x" ? 0 : (counterCodeAtBlock.length - 2) / 2
+          }`,
+        );
+      }
       const counterCode = await l2Provider.getCode(counterAddress);
       if (counterCode === "0x") {
         logger.error(

--- a/e2e/src/credible-layer.spec.ts
+++ b/e2e/src/credible-layer.spec.ts
@@ -3,9 +3,10 @@ import { ethers, TransactionRequest } from "ethers";
 import { config } from "./config/tests-config";
 import { AssertionDaClient, AssertionDaError } from "./common/utils";
 import { STATE_ORACLE_ADDRESS } from "./common/constants";
-import CounterArtifact from "../../contracts/out/SimpleCounterAssertion.sol/Counter.json" assert { type: "json" };
+import CounterArtifact from "../../contracts/out/SimpleCounterAssertion.sol/Counter.json";
 
 const ADMIN_VERIFIER_OWNER_ADDRESS = "0x3e06372d794a48552203069915eA91b223297736" as const;
+const EXPECTED_COUNTER_ADDRESS = "0x3bAF7216467522Bb7cfd48f7f216867384296feB" as const;
 const stateOracleAbi = [
   "function ASSERTION_TIMELOCK_BLOCKS() view returns (uint128)",
   "function MAX_ASSERTIONS_PER_AA() view returns (uint128)",
@@ -17,6 +18,8 @@ const adminVerifierAbi = [
 ];
 
 const assertionDaEndpoint = config.getAssertionDaEndpoint();
+
+const formatNullableBigInt = (value: bigint | null | undefined) => (value == null ? "null" : value.toString());
 
 // Skip the entire suite when the Credible stack is not running.
 const describeCredible = assertionDaEndpoint ? describe : describe.skip;
@@ -90,10 +93,19 @@ describeCredible("Credible layer e2e test suite", () => {
 
     expect.assertions(2);
 
-    const { assertionId, signature } = await assertionDaClient.storeAssertion(testAssertionArtifact, constructorArgs, {
-      cwd: pclWorkingDir,
-      timeoutMs: pclTimeoutMs,
-    });
+    const storeOptions: { cwd?: string; timeoutMs?: number } = {};
+    if (pclWorkingDir) {
+      storeOptions.cwd = pclWorkingDir;
+    }
+    if (pclTimeoutMs !== undefined) {
+      storeOptions.timeoutMs = pclTimeoutMs;
+    }
+
+    const { assertionId, signature } = await assertionDaClient.storeAssertion(
+      testAssertionArtifact,
+      constructorArgs,
+      storeOptions,
+    );
 
     expect(assertionId).toMatch(/^0x[0-9a-fA-F]+$/);
     expect(signature).toMatch(/^0x[0-9a-fA-F]+$/);
@@ -141,151 +153,178 @@ describeCredible("Credible layer e2e test suite", () => {
     const adminVerifierResult = await adminVerifier.verifyAdmin(STATE_ORACLE_ADDRESS, stateOracleOwner, "0x");
     expect(adminVerifierResult).toBe(true);
 
-    const counterBytecode =
-      typeof CounterArtifact.bytecode === "string" ? CounterArtifact.bytecode : CounterArtifact.bytecode.object;
-
-    const counterFactory = new ethers.ContractFactory(CounterArtifact.abi, counterBytecode, deployer);
-    logger.info(
-      `Counter artifact info. bytecodeBytes=${counterBytecode ? (counterBytecode.length - 2) / 2 : 0} abiEntries=${CounterArtifact.abi.length}`,
-    );
-
-    const formatNullableBigInt = (value: bigint | null | undefined) => (value == null ? "null" : value.toString());
-
-    const counterDeployOverrides: TransactionRequest = {};
-
-    const feeData = await l2Provider.getFeeData();
-    if (feeData.maxPriorityFeePerGas && feeData.maxFeePerGas) {
-      counterDeployOverrides.maxPriorityFeePerGas = feeData.maxPriorityFeePerGas;
-      counterDeployOverrides.maxFeePerGas = feeData.maxFeePerGas;
-    } else if (feeData.gasPrice) {
-      counterDeployOverrides.gasPrice = feeData.gasPrice;
-    }
-
-    const deployTx = await counterFactory.getDeployTransaction();
-    const deployDataBytes = deployTx.data ? (deployTx.data.length - 2) / 2 : 0;
-    logger.info(
-      `Prepared Counter deployment transaction request. to=${deployTx.to ?? "<constructor>"} dataBytes=${deployDataBytes} value=${formatNullableBigInt(deployTx.value)}`,
-    );
-    if (deployDataBytes === 0) {
-      logger.error(
-        "Counter deployment transaction missing init code bytes; the artifact bytecode may be empty or not wired correctly.",
-      );
-    }
-    const estimationRequest: TransactionRequest = {
-      ...counterDeployOverrides,
-      from: deployerAddress,
-      to: deployTx.to,
-      data: deployTx.data,
-      value: deployTx.value,
-    };
-    const estimatedGas = await deployer.estimateGas(estimationRequest);
-    const bufferedGas = (estimatedGas * 12n) / 10n;
-    counterDeployOverrides.gasLimit = counterDeployOverrides.gasLimit
-      ? counterDeployOverrides.gasLimit > bufferedGas
-        ? counterDeployOverrides.gasLimit
-        : bufferedGas
-      : bufferedGas;
-
-    const counterConstructorGas = await l2Provider.estimateGas(estimationRequest);
-    logger.info(
-      `Counter gas estimation. rawEstimate=${formatNullableBigInt(counterConstructorGas)} buffered=${formatNullableBigInt(
-        (counterConstructorGas * 12n) / 10n,
-      )}`,
-    );
-    const deploymentNonceBefore = await l2Provider.getTransactionCount(deployerAddress, "latest");
-    const counterDeployTx = await deployer.sendTransaction({
-      ...estimationRequest,
-      gasLimit: (counterConstructorGas * 12n) / 10n,
-    });
-    logger.info(
-      `Submitted Counter deployment transaction. hash=${counterDeployTx.hash} nonce=${counterDeployTx.nonce} from=${counterDeployTx.from} gasLimit=${formatNullableBigInt(counterDeployTx.gasLimit)} maxFeePerGas=${formatNullableBigInt(counterDeployTx.maxFeePerGas)} maxPriorityFeePerGas=${formatNullableBigInt(counterDeployTx.maxPriorityFeePerGas)} gasPrice=${formatNullableBigInt(counterDeployTx.gasPrice)} chainId=${formatNullableBigInt(counterDeployTx.chainId)}`,
-    );
-    const deploymentReceipt = await counterDeployTx.wait();
-    expect(deploymentReceipt?.status).toEqual(1);
-
-    const deploymentNonce = counterDeployTx.nonce ?? -1;
-    expect(deploymentNonce).toBe(deploymentNonceBefore);
-
-    const counterAddress = deploymentReceipt?.contractAddress ?? ethers.ZeroAddress;
-    const confirmations =
-      typeof deploymentReceipt?.confirmations === "function"
-        ? await deploymentReceipt.confirmations()
-        : deploymentReceipt?.confirmations ?? "null";
-    logger.info(
-      `Counter deployment receipt. txHash=${counterDeployTx.hash} status=${deploymentReceipt?.status ?? "null"} contractAddress=${counterAddress} blockNumber=${
-        deploymentReceipt?.blockNumber ?? "null"
-      } confirmations=${confirmations} gasUsed=${formatNullableBigInt(
-        deploymentReceipt?.gasUsed,
-      )} cumulativeGasUsed=${formatNullableBigInt(
-        deploymentReceipt?.cumulativeGasUsed,
-      )} effectiveGasPrice=${formatNullableBigInt(deploymentReceipt?.effectiveGasPrice)} type=${
-        deploymentReceipt?.type ?? "null"
-      }`,
-    );
-    if (counterAddress === ethers.ZeroAddress) {
-      logger.error(
-        `Counter deployment returned zero address. txHash=${counterDeployTx.hash} logsLength=${deploymentReceipt?.logs?.length ?? 0}`,
-      );
-    }
-    expect(counterAddress).not.toEqual(ethers.ZeroAddress);
-
-    const txOnChain = await l2Provider.getTransaction(counterDeployTx.hash);
-    logger.info(
-      `Counter deployment transaction on-chain. blockNumber=${txOnChain?.blockNumber ?? "null"} gasLimit=${formatNullableBigInt(
-        txOnChain?.gasLimit,
-      )} gasPrice=${formatNullableBigInt(txOnChain?.gasPrice)} maxFeePerGas=${formatNullableBigInt(
-        txOnChain?.maxFeePerGas,
-      )} maxPriorityFeePerGas=${formatNullableBigInt(txOnChain?.maxPriorityFeePerGas)} dataBytes=${
-        txOnChain?.data ? (txOnChain.data.length - 2) / 2 : 0
-      } value=${formatNullableBigInt(txOnChain?.value)}`,
-    );
-
-    if (deploymentReceipt) {
-      const receiptLogSummary = (deploymentReceipt.logs ?? []).map((log) => ({
-        index: log.index,
-        address: log.address,
-        topics: log.topics,
-        dataBytes: (log.data.length - 2) / 2,
-      }));
-      logger.info(
-        `Counter deployment receipt logs summary. logsCount=${receiptLogSummary.length} details=${JSON.stringify(receiptLogSummary)}`,
-      );
-
-      const deploymentBlock = deploymentReceipt.blockNumber
-        ? await l2Provider.getBlock(deploymentReceipt.blockNumber)
-        : null;
-      if (deploymentBlock) {
-        logger.info(
-          `Counter deployment block info. blockNumber=${deploymentBlock.number} hash=${deploymentBlock.hash} parentHash=${deploymentBlock.parentHash} stateRoot=${deploymentBlock.stateRoot} txCount=${deploymentBlock.transactions.length}`,
-        );
-      }
-    }
-
-    logger.info(
-      `Counter deployed for Credible Layer tests. address=${counterAddress} nonce=${deploymentNonce} deployer=${deployerAddress} gasUsed=${deploymentReceipt?.gasUsed}`,
-    );
-    if (counterAddress !== ethers.ZeroAddress) {
-      const counterCodeAtBlock = deploymentReceipt?.blockNumber
-        ? await l2Provider.getCode(counterAddress, deploymentReceipt.blockNumber)
-        : null;
-      if (counterCodeAtBlock != null) {
-        logger.info(
-          `Counter contract code at deployment block. blockNumber=${deploymentReceipt?.blockNumber ?? "null"} byteLength=${
-            counterCodeAtBlock === "0x" ? 0 : (counterCodeAtBlock.length - 2) / 2
-          }`,
-        );
-      }
-      const counterCode = await l2Provider.getCode(counterAddress);
-      if (counterCode === "0x") {
-        logger.error(
-          `Counter deployment produced empty code. address=${counterAddress} txHash=${counterDeployTx.hash} blockNumber=${deploymentReceipt?.blockNumber ?? "null"}`,
-        );
-      } else {
-        logger.info(
-          `Counter contract code detected. address=${counterAddress} byteLength=${(counterCode.length - 2) / 2}`,
-        );
-      }
-      expect(counterCode).not.toEqual("0x");
-    }
+    const counterAddress = await ensureCounterDeployment({ logger, l2Provider, deployer, deployerAddress });
+    expect(counterAddress).toEqual(EXPECTED_COUNTER_ADDRESS);
   });
 });
+
+type CounterDeploymentContext = {
+  logger: typeof global.logger;
+  l2Provider: ReturnType<typeof config.getL2Provider>;
+  deployer: ReturnType<ReturnType<typeof config.getL2AccountManager>["whaleAccount"]>;
+  deployerAddress: string;
+};
+
+const ensureCounterDeployment = async ({ logger, l2Provider, deployer, deployerAddress }: CounterDeploymentContext) => {
+  const existingCode = await l2Provider.getCode(EXPECTED_COUNTER_ADDRESS);
+  if (existingCode !== "0x") {
+    logger.info(
+      `Counter already deployed at expected address. address=${EXPECTED_COUNTER_ADDRESS} byteLength=${(existingCode.length - 2) / 2}`,
+    );
+    return EXPECTED_COUNTER_ADDRESS;
+  }
+
+  logger.info(
+    `No counter code detected at expected address. proceeding with deployment. address=${EXPECTED_COUNTER_ADDRESS} deployer=${deployerAddress}`,
+  );
+
+  const counterBytecode =
+    typeof CounterArtifact.bytecode === "string" ? CounterArtifact.bytecode : CounterArtifact.bytecode.object;
+
+  const counterFactory = new ethers.ContractFactory(CounterArtifact.abi, counterBytecode, deployer);
+  logger.info(
+    `Counter artifact info. bytecodeBytes=${counterBytecode ? (counterBytecode.length - 2) / 2 : 0} abiEntries=${CounterArtifact.abi.length}`,
+  );
+
+  const counterDeployOverrides: TransactionRequest = {};
+
+  const feeData = await l2Provider.getFeeData();
+  if (feeData.maxPriorityFeePerGas && feeData.maxFeePerGas) {
+    counterDeployOverrides.maxPriorityFeePerGas = feeData.maxPriorityFeePerGas;
+    counterDeployOverrides.maxFeePerGas = feeData.maxFeePerGas;
+  } else if (feeData.gasPrice) {
+    counterDeployOverrides.gasPrice = feeData.gasPrice;
+  }
+
+  const deployTx = await counterFactory.getDeployTransaction();
+  const deployDataBytes = deployTx.data ? (deployTx.data.length - 2) / 2 : 0;
+  logger.info(
+    `Prepared Counter deployment transaction request. target=<constructor> dataBytes=${deployDataBytes} value=${formatNullableBigInt(
+      deployTx.value ?? null,
+    )}`,
+  );
+  if (deployDataBytes === 0) {
+    logger.error(
+      "Counter deployment transaction missing init code bytes; the artifact bytecode may be empty or not wired correctly.",
+    );
+  }
+  const estimationRequest: TransactionRequest = {
+    ...counterDeployOverrides,
+    from: deployerAddress,
+    data: deployTx.data,
+  };
+  if (deployTx.value != null) {
+    estimationRequest.value = deployTx.value;
+  }
+  const estimatedGas = await deployer.estimateGas(estimationRequest);
+  const bufferedGas = (estimatedGas * 12n) / 10n;
+  counterDeployOverrides.gasLimit = bufferedGas;
+
+  const counterConstructorGas = await l2Provider.estimateGas(estimationRequest);
+  logger.info(
+    `Counter gas estimation. rawEstimate=${formatNullableBigInt(counterConstructorGas)} buffered=${formatNullableBigInt(
+      (counterConstructorGas * 12n) / 10n,
+    )}`,
+  );
+  const deploymentNonceBefore = await l2Provider.getTransactionCount(deployerAddress, "latest");
+  const counterDeployTx = await deployer.sendTransaction({
+    ...estimationRequest,
+    gasLimit: (counterConstructorGas * 12n) / 10n,
+  });
+  logger.info(
+    `Submitted Counter deployment transaction. hash=${counterDeployTx.hash} nonce=${counterDeployTx.nonce} from=${counterDeployTx.from} gasLimit=${formatNullableBigInt(counterDeployTx.gasLimit)} maxFeePerGas=${formatNullableBigInt(counterDeployTx.maxFeePerGas)} maxPriorityFeePerGas=${formatNullableBigInt(counterDeployTx.maxPriorityFeePerGas)} gasPrice=${formatNullableBigInt(counterDeployTx.gasPrice)} chainId=${formatNullableBigInt(counterDeployTx.chainId)}`,
+  );
+  const deploymentReceipt = await counterDeployTx.wait();
+  expect(deploymentReceipt?.status).toEqual(1);
+
+  const deploymentNonce = counterDeployTx.nonce ?? -1;
+  expect(deploymentNonce).toBe(deploymentNonceBefore);
+
+  const counterAddress = deploymentReceipt?.contractAddress ?? ethers.ZeroAddress;
+  const confirmations =
+    typeof deploymentReceipt?.confirmations === "function"
+      ? await deploymentReceipt.confirmations()
+      : deploymentReceipt?.confirmations ?? "null";
+  logger.info(
+    `Counter deployment receipt. txHash=${counterDeployTx.hash} status=${deploymentReceipt?.status ?? "null"} contractAddress=${counterAddress} blockNumber=${
+      deploymentReceipt?.blockNumber ?? "null"
+    } confirmations=${confirmations} gasUsed=${formatNullableBigInt(
+      deploymentReceipt?.gasUsed,
+    )} cumulativeGasUsed=${formatNullableBigInt(
+      deploymentReceipt?.cumulativeGasUsed,
+    )} effectiveGasPrice=${formatNullableBigInt(
+      (deploymentReceipt as { effectiveGasPrice?: bigint } | null)?.effectiveGasPrice,
+    )} type=${deploymentReceipt?.type ?? "null"}`,
+  );
+  if (counterAddress === ethers.ZeroAddress) {
+    logger.error(
+      `Counter deployment returned zero address. txHash=${counterDeployTx.hash} logsLength=${deploymentReceipt?.logs?.length ?? 0}`,
+    );
+  }
+  expect(counterAddress).not.toEqual(ethers.ZeroAddress);
+  if (counterAddress !== EXPECTED_COUNTER_ADDRESS) {
+    throw new Error(
+      `Counter deployed at unexpected address. expected=${EXPECTED_COUNTER_ADDRESS} actual=${counterAddress} txHash=${counterDeployTx.hash}`,
+    );
+  }
+
+  const txOnChain = await l2Provider.getTransaction(counterDeployTx.hash);
+  logger.info(
+    `Counter deployment transaction on-chain. blockNumber=${txOnChain?.blockNumber ?? "null"} gasLimit=${formatNullableBigInt(
+      txOnChain?.gasLimit,
+    )} gasPrice=${formatNullableBigInt(txOnChain?.gasPrice)} maxFeePerGas=${formatNullableBigInt(
+      txOnChain?.maxFeePerGas,
+    )} maxPriorityFeePerGas=${formatNullableBigInt(txOnChain?.maxPriorityFeePerGas)} dataBytes=${
+      txOnChain?.data ? (txOnChain.data.length - 2) / 2 : 0
+    } value=${formatNullableBigInt(txOnChain?.value)}`,
+  );
+
+  if (deploymentReceipt) {
+    const receiptLogSummary = (deploymentReceipt.logs ?? []).map((log) => ({
+      index: log.index,
+      address: log.address,
+      topics: log.topics,
+      dataBytes: (log.data.length - 2) / 2,
+    }));
+    logger.info(
+      `Counter deployment receipt logs summary. logsCount=${receiptLogSummary.length} details=${JSON.stringify(receiptLogSummary)}`,
+    );
+
+    const deploymentBlock = deploymentReceipt.blockNumber
+      ? await l2Provider.getBlock(deploymentReceipt.blockNumber)
+      : null;
+    if (deploymentBlock) {
+      logger.info(
+        `Counter deployment block info. blockNumber=${deploymentBlock.number} hash=${deploymentBlock.hash} parentHash=${deploymentBlock.parentHash} stateRoot=${deploymentBlock.stateRoot} txCount=${deploymentBlock.transactions.length}`,
+      );
+    }
+  }
+
+  logger.info(
+    `Counter deployed for Credible Layer tests. address=${counterAddress} nonce=${deploymentNonce} deployer=${deployerAddress} gasUsed=${deploymentReceipt?.gasUsed}`,
+  );
+
+  const counterCodeAtBlock = deploymentReceipt?.blockNumber
+    ? await l2Provider.getCode(counterAddress, deploymentReceipt.blockNumber)
+    : null;
+  if (counterCodeAtBlock != null) {
+    logger.info(
+      `Counter contract code at deployment block. blockNumber=${deploymentReceipt?.blockNumber ?? "null"} byteLength=${
+        counterCodeAtBlock === "0x" ? 0 : (counterCodeAtBlock.length - 2) / 2
+      }`,
+    );
+  }
+  const counterCode = await l2Provider.getCode(EXPECTED_COUNTER_ADDRESS);
+  if (counterCode === "0x") {
+    logger.error(
+      `Counter deployment produced empty code. address=${EXPECTED_COUNTER_ADDRESS} txHash=${counterDeployTx.hash} blockNumber=${deploymentReceipt?.blockNumber ?? "null"}`,
+    );
+  } else {
+    logger.info(
+      `Counter contract code detected. address=${EXPECTED_COUNTER_ADDRESS} byteLength=${(counterCode.length - 2) / 2}`,
+    );
+  }
+  expect(counterCode).not.toEqual("0x");
+
+  return EXPECTED_COUNTER_ADDRESS;
+};

--- a/e2e/src/credible-layer.spec.ts
+++ b/e2e/src/credible-layer.spec.ts
@@ -8,6 +8,21 @@ const assertionDaEndpoint = config.getAssertionDaEndpoint();
 // Skip the entire suite when the Credible stack is not running.
 const describeCredible = assertionDaEndpoint ? describe : describe.skip;
 
+// Gold Path:
+// 1. When pcl store is executed
+//    a. when the pcl store succeeds
+//       i. the assertion should be retrievable from the assertion da
+//          1. when a user submits a transaction to register the transaction on-chain
+//             a. It should revert if the sender is not the AA manager
+//             b. when the transaction is included
+//                i. The assertion should be retrievable from the smart contract
+//                ii. When block.number >= timelock
+//                    1. A transaction incrementing the Counter contract should be included
+//                       a. because the invariants only allow to increment it once
+//                iii. When the block.number >= timelock
+//                     1. An invalidating transaction should not be included in the block
+//                        a. because the assertion invariant is triggered
+
 describeCredible("Credible layer e2e test suite", () => {
   let assertionDaClient: AssertionDaClient;
 
@@ -79,8 +94,9 @@ describeCredible("Credible layer e2e test suite", () => {
 
   it("tracks end-to-end flows between the Credible sidecar and Assertion DA", async () => {
     // Placeholder for the full Credible flow validation.
-    // TODO: Submit an assertion through the sidecar, wait for it to propagate,
-    // and verify the state oracle contract is updated accordingly.
+    // TODO: deploy credible layer contracts, deploy the counter contract,
+    // register the counter assertion using pcl and submit to da,
+    // increment contract once and verify it passes, do it a second time and verify it fails
     expect(true).toBeTruthy();
   });
 });

--- a/e2e/src/credible-layer.spec.ts
+++ b/e2e/src/credible-layer.spec.ts
@@ -1,7 +1,20 @@
 import { beforeAll, describe, expect, it } from "@jest/globals";
+import { ethers, TransactionRequest } from "ethers";
 import { config } from "./config/tests-config";
 import { AssertionDaClient, AssertionDaError } from "./common/utils";
 import { STATE_ORACLE_ADDRESS } from "./common/constants";
+import CounterArtifact from "../../contracts/out/SimpleCounterAssertion.sol/Counter.json" assert { type: "json" };
+
+const ADMIN_VERIFIER_OWNER_ADDRESS = "0x3e06372d794a48552203069915eA91b223297736" as const;
+const stateOracleAbi = [
+  "function ASSERTION_TIMELOCK_BLOCKS() view returns (uint128)",
+  "function MAX_ASSERTIONS_PER_AA() view returns (uint128)",
+  "function DA_VERIFIER() view returns (address)",
+  "function owner() view returns (address)",
+];
+const adminVerifierAbi = [
+  "function verifyAdmin(address contractAddress, address requester, bytes data) view returns (bool)",
+];
 
 const assertionDaEndpoint = config.getAssertionDaEndpoint();
 
@@ -92,11 +105,114 @@ describeCredible("Credible layer e2e test suite", () => {
     it.skip("stores a new assertion via the PCL CLI", storeAssertion);
   }
 
-  it("tracks end-to-end flows between the Credible sidecar and Assertion DA", async () => {
-    // Placeholder for the full Credible flow validation.
-    // TODO: deploy credible layer contracts, deploy the counter contract,
-    // register the counter assertion using pcl and submit to da,
-    // increment contract once and verify it passes, do it a second time and verify it fails
-    expect(true).toBeTruthy();
+  it("deploys the Counter contract after verifying Credible Layer core deployments", async () => {
+    const logger = global.logger;
+    const l2Provider = config.getL2Provider();
+    const deployer = config.getL2AccountManager().whaleAccount(0);
+    const deployerAddress = await deployer.getAddress();
+
+    logger.info(
+      `Using whale account to verify Credible Layer core contracts. deployer=${deployerAddress} stateOracle=${STATE_ORACLE_ADDRESS} adminVerifier=${ADMIN_VERIFIER_OWNER_ADDRESS}`,
+    );
+
+    const [stateOracleCode, adminVerifierCode] = await Promise.all([
+      l2Provider.getCode(STATE_ORACLE_ADDRESS),
+      l2Provider.getCode(ADMIN_VERIFIER_OWNER_ADDRESS),
+    ]);
+
+    expect(stateOracleCode).not.toEqual("0x");
+    expect(adminVerifierCode).not.toEqual("0x");
+
+    const stateOracle = new ethers.Contract(STATE_ORACLE_ADDRESS, stateOracleAbi, l2Provider);
+    const adminVerifier = new ethers.Contract(ADMIN_VERIFIER_OWNER_ADDRESS, adminVerifierAbi, l2Provider);
+
+    const [timelockBlocks, maxAssertionsPerAa, daVerifierAddress, stateOracleOwner] = await Promise.all([
+      stateOracle.ASSERTION_TIMELOCK_BLOCKS(),
+      stateOracle.MAX_ASSERTIONS_PER_AA(),
+      stateOracle.DA_VERIFIER(),
+      stateOracle.owner(),
+    ]);
+
+    expect(timelockBlocks > 0n).toBe(true);
+    expect(maxAssertionsPerAa > 0n).toBe(true);
+    expect(daVerifierAddress).not.toEqual(ethers.ZeroAddress);
+    expect(stateOracleOwner).not.toEqual(ethers.ZeroAddress);
+
+    const adminVerifierResult = await adminVerifier.verifyAdmin(STATE_ORACLE_ADDRESS, stateOracleOwner, "0x");
+    expect(adminVerifierResult).toBe(true);
+
+    const counterBytecode =
+      typeof CounterArtifact.bytecode === "string" ? CounterArtifact.bytecode : CounterArtifact.bytecode.object;
+
+    const counterFactory = new ethers.ContractFactory(CounterArtifact.abi, counterBytecode, deployer);
+
+    const formatNullableBigInt = (value: bigint | null | undefined) => (value == null ? "null" : value.toString());
+
+    const counterDeployOverrides: TransactionRequest = {};
+
+    const feeData = await l2Provider.getFeeData();
+    if (feeData.maxPriorityFeePerGas && feeData.maxFeePerGas) {
+      counterDeployOverrides.maxPriorityFeePerGas = feeData.maxPriorityFeePerGas;
+      counterDeployOverrides.maxFeePerGas = feeData.maxFeePerGas;
+    } else if (feeData.gasPrice) {
+      counterDeployOverrides.gasPrice = feeData.gasPrice;
+    }
+
+    const deployTx = counterFactory.getDeployTransaction();
+    const estimationRequest: TransactionRequest = {
+      ...deployTx,
+      ...counterDeployOverrides,
+      from: deployerAddress,
+    };
+    const estimatedGas = await deployer.estimateGas(estimationRequest);
+    const bufferedGas = (estimatedGas * 12n) / 10n;
+    counterDeployOverrides.gasLimit = counterDeployOverrides.gasLimit
+      ? counterDeployOverrides.gasLimit > bufferedGas
+        ? counterDeployOverrides.gasLimit
+        : bufferedGas
+      : bufferedGas;
+
+    const counterConstructorGas = await l2Provider.estimateGas(estimationRequest);
+    const deploymentNonceBefore = await l2Provider.getTransactionCount(deployerAddress, "latest");
+    const counterDeployTx = await deployer.sendTransaction({
+      ...estimationRequest,
+      gasLimit: (counterConstructorGas * 12n) / 10n,
+    });
+    logger.info(
+      `Submitted Counter deployment transaction. hash=${counterDeployTx.hash} nonce=${counterDeployTx.nonce} from=${counterDeployTx.from} gasLimit=${formatNullableBigInt(counterDeployTx.gasLimit)} maxFeePerGas=${formatNullableBigInt(counterDeployTx.maxFeePerGas)} maxPriorityFeePerGas=${formatNullableBigInt(counterDeployTx.maxPriorityFeePerGas)} gasPrice=${formatNullableBigInt(counterDeployTx.gasPrice)} chainId=${formatNullableBigInt(counterDeployTx.chainId)}`,
+    );
+    const deploymentReceipt = await counterDeployTx.wait();
+    expect(deploymentReceipt?.status).toEqual(1);
+
+    const deploymentNonce = counterDeployTx.nonce ?? -1;
+    expect(deploymentNonce).toBe(deploymentNonceBefore);
+
+    const counterAddress = deploymentReceipt?.contractAddress ?? ethers.ZeroAddress;
+    logger.info(
+      `Counter deployment receipt. txHash=${counterDeployTx.hash} status=${deploymentReceipt?.status ?? "null"} contractAddress=${counterAddress} blockNumber=${deploymentReceipt?.blockNumber ?? "null"} confirmations=${deploymentReceipt?.confirmations ?? "null"} gasUsed=${formatNullableBigInt(deploymentReceipt?.gasUsed)} cumulativeGasUsed=${formatNullableBigInt(deploymentReceipt?.cumulativeGasUsed)} effectiveGasPrice=${formatNullableBigInt(deploymentReceipt?.effectiveGasPrice)} type=${deploymentReceipt?.type ?? "null"}`,
+    );
+    if (counterAddress === ethers.ZeroAddress) {
+      logger.error(
+        `Counter deployment returned zero address. txHash=${counterDeployTx.hash} logsLength=${deploymentReceipt?.logs?.length ?? 0}`,
+      );
+    }
+    expect(counterAddress).not.toEqual(ethers.ZeroAddress);
+
+    logger.info(
+      `Counter deployed for Credible Layer tests. address=${counterAddress} nonce=${deploymentNonce} deployer=${deployerAddress} gasUsed=${deploymentReceipt?.gasUsed}`,
+    );
+    if (counterAddress !== ethers.ZeroAddress) {
+      const counterCode = await l2Provider.getCode(counterAddress);
+      if (counterCode === "0x") {
+        logger.error(
+          `Counter deployment produced empty code. address=${counterAddress} txHash=${counterDeployTx.hash} blockNumber=${deploymentReceipt?.blockNumber ?? "null"}`,
+        );
+      } else {
+        logger.info(
+          `Counter contract code detected. address=${counterAddress} byteLength=${(counterCode.length - 2) / 2}`,
+        );
+      }
+      expect(counterCode).not.toEqual("0x");
+    }
   });
 });

--- a/e2e/src/credible-layer.spec.ts
+++ b/e2e/src/credible-layer.spec.ts
@@ -333,34 +333,30 @@ describeCredible("Credible layer e2e test suite", () => {
     const secondTx = await counter.increment();
     logger.info(`Submitted second increment transaction. txHash=${secondTx.hash}`);
 
+    const parsedSecondTimeout = Number.parseInt(process.env.CREDIBLE_ASSERTION_TX_TIMEOUT_MS ?? "120000", 10);
+    const secondTxTimeoutMs = Number.isFinite(parsedSecondTimeout) ? parsedSecondTimeout : 120000;
     let secondReceipt: ethers.TransactionReceipt | null = null;
-    let secondErrorMessage: string | null = null;
+    let secondError: Error | null = null;
 
     try {
-      secondReceipt = await secondTx.wait();
+      secondReceipt = await l2Provider.waitForTransaction(secondTx.hash, undefined, secondTxTimeoutMs);
     } catch (error) {
-      secondErrorMessage = error instanceof Error ? error.message : String(error);
-      if (
-        typeof error === "object" &&
-        error !== null &&
-        "receipt" in error &&
-        (error as { receipt?: ethers.TransactionReceipt | null }).receipt
-      ) {
-        secondReceipt = (error as { receipt?: ethers.TransactionReceipt | null }).receipt ?? null;
-      }
-      if (secondErrorMessage) {
-        logger.info(`Second increment failed as expected. signer=${incrementAddress} error=${secondErrorMessage}`);
-      }
+      secondError = error instanceof Error ? error : new Error(String(error));
     }
 
     if (secondReceipt) {
+      logger.info(
+        `Second increment mined. status=${secondReceipt.status ?? "null"} blockNumber=${
+          secondReceipt.blockNumber ?? "null"
+        }`,
+      );
       expect(secondReceipt.status).not.toEqual(1);
     } else {
-      expect(secondErrorMessage).toBeTruthy();
-    }
-
-    if (secondErrorMessage) {
-      expect(secondErrorMessage.toLowerCase()).toContain("counter cannot be greater than 1");
+      const errorMessage = secondError?.message ?? "timeout awaiting transaction";
+      expect(errorMessage.toLowerCase()).toMatch(/timeout|replacement|revert/);
+      logger.info(
+        `Second increment not included within timeout as expected. signer=${incrementAddress} reason=${errorMessage}`,
+      );
     }
 
     const finalCounterValue = await counterReadonly.number();

--- a/e2e/src/credible-layer.spec.ts
+++ b/e2e/src/credible-layer.spec.ts
@@ -1,9 +1,11 @@
 import { beforeAll, describe, expect, it } from "@jest/globals";
 import { ethers, TransactionRequest } from "ethers";
+import type { Signer } from "ethers";
 import { config } from "./config/tests-config";
-import { AssertionDaClient, AssertionDaError } from "./common/utils";
+import { AssertionDaClient, AssertionDaError, pollForBlockNumber } from "./common/utils";
 import { STATE_ORACLE_ADDRESS } from "./common/constants";
 import CounterArtifact from "../../contracts/out/SimpleCounterAssertion.sol/Counter.json";
+import SimpleCounterAssertionArtifact from "../../contracts/out/SimpleCounterAssertion.sol/SimpleCounterAssertion.json";
 
 const ADMIN_VERIFIER_OWNER_ADDRESS = "0x3e06372d794a48552203069915eA91b223297736" as const;
 const EXPECTED_COUNTER_ADDRESS = "0x3bAF7216467522Bb7cfd48f7f216867384296feB" as const;
@@ -12,6 +14,12 @@ const stateOracleAbi = [
   "function MAX_ASSERTIONS_PER_AA() view returns (uint128)",
   "function DA_VERIFIER() view returns (address)",
   "function owner() view returns (address)",
+  "function registerAssertionAdopter(address contractAddress, address adminVerifier, bytes data)",
+  "function addAssertion(address contractAddress, bytes32 assertionId, bytes metadata, bytes proof)",
+  "function hasAssertion(address contractAddress, bytes32 assertionId) view returns (bool)",
+  "function getAssertionWindow(address contractAddress, bytes32 assertionId) view returns (uint128 activationBlock, uint128 deactivationBlock)",
+  "function getManager(address contractAddress) view returns (address)",
+  "function isAdminVerifierRegistered(address adminVerifier) view returns (bool)",
 ];
 const adminVerifierAbi = [
   "function verifyAdmin(address contractAddress, address requester, bytes data) view returns (bool)",
@@ -20,6 +28,9 @@ const adminVerifierAbi = [
 const assertionDaEndpoint = config.getAssertionDaEndpoint();
 
 const formatNullableBigInt = (value: bigint | null | undefined) => (value == null ? "null" : value.toString());
+
+const normalizeAddress = (address: string) => ethers.getAddress(address);
+const addressesEqual = (a: string, b: string) => normalizeAddress(a) === normalizeAddress(b);
 
 // Skip the entire suite when the Credible stack is not running.
 const describeCredible = assertionDaEndpoint ? describe : describe.skip;
@@ -41,6 +52,7 @@ const describeCredible = assertionDaEndpoint ? describe : describe.skip;
 
 describeCredible("Credible layer e2e test suite", () => {
   let assertionDaClient: AssertionDaClient;
+  let latestAssertionId: string | null = null;
 
   const knownAssertionId = process.env.CREDIBLE_TEST_ASSERTION_ID;
   const testAssertionArtifact = process.env.CREDIBLE_ASSERTION_ARTIFACT;
@@ -57,7 +69,7 @@ describeCredible("Credible layer e2e test suite", () => {
         .split(",")
         .map((arg) => arg.trim())
         .filter(Boolean)
-    : [STATE_ORACLE_ADDRESS];
+    : [EXPECTED_COUNTER_ADDRESS];
 
   beforeAll(() => {
     if (!assertionDaEndpoint) {
@@ -155,6 +167,204 @@ describeCredible("Credible layer e2e test suite", () => {
 
     const counterAddress = await ensureCounterDeployment({ logger, l2Provider, deployer, deployerAddress });
     expect(counterAddress).toEqual(EXPECTED_COUNTER_ADDRESS);
+  });
+
+  it("registers the SimpleCounter assertion and approves it on the StateOracle", async () => {
+    if (!assertionDaClient) {
+      throw new AssertionDaError("Assertion DA client not initialized");
+    }
+
+    const logger = global.logger;
+    const l2Provider = config.getL2Provider();
+    const accountManager = config.getL2AccountManager();
+    const defaultManagerSigner = accountManager.whaleAccount(0);
+    const defaultManagerAddress = normalizeAddress(await defaultManagerSigner.getAddress());
+
+    const stateOracleReadonly = new ethers.Contract(STATE_ORACLE_ADDRESS, stateOracleAbi, l2Provider);
+
+    const adminVerifierRegistered = await stateOracleReadonly.isAdminVerifierRegistered(ADMIN_VERIFIER_OWNER_ADDRESS);
+    expect(adminVerifierRegistered).toBe(true);
+
+    const initialManager = await stateOracleReadonly.getManager(EXPECTED_COUNTER_ADDRESS);
+    let managerSigner: Signer = defaultManagerSigner;
+    let managerAddress = defaultManagerAddress;
+
+    if (initialManager !== ethers.ZeroAddress && !addressesEqual(initialManager, defaultManagerAddress)) {
+      const normalizedManager = normalizeAddress(initialManager);
+      logger.info(
+        `Counter already registered with manager ${normalizedManager}. Attempting to use RPC signer for transactions.`,
+      );
+      try {
+        managerSigner = await l2Provider.getSigner(normalizedManager);
+        managerAddress = normalizeAddress(await managerSigner.getAddress());
+      } catch (error) {
+        throw new Error(
+          `Unable to obtain signer for registered counter manager ${normalizedManager}: ${(error as Error).message}`,
+        );
+      }
+    } else if (initialManager === ethers.ZeroAddress) {
+      logger.info(
+        `Counter not yet registered with StateOracle. Using whale account ${defaultManagerAddress} as manager.`,
+      );
+    } else {
+      logger.info(
+        `Using existing counter manager ${defaultManagerAddress} from whale account for assertion registration.`,
+      );
+    }
+
+    const stateOracle = stateOracleReadonly.connect(managerSigner);
+
+    if (initialManager === ethers.ZeroAddress) {
+      const registerTx = await stateOracle.registerAssertionAdopter(
+        EXPECTED_COUNTER_ADDRESS,
+        ADMIN_VERIFIER_OWNER_ADDRESS,
+        "0x",
+      );
+      const registerReceipt = await registerTx.wait();
+      expect(registerReceipt?.status).toEqual(1);
+
+      const registeredManager = await stateOracleReadonly.getManager(EXPECTED_COUNTER_ADDRESS);
+      expect(addressesEqual(registeredManager, managerAddress)).toBe(true);
+      logger.info(
+        `Registered counter contract with StateOracle. counter=${EXPECTED_COUNTER_ADDRESS} manager=${managerAddress} txHash=${registerTx.hash}`,
+      );
+    }
+
+    const simpleAssertionBytecode =
+      typeof SimpleCounterAssertionArtifact.bytecode === "string"
+        ? SimpleCounterAssertionArtifact.bytecode
+        : SimpleCounterAssertionArtifact.bytecode.object;
+
+    if (!simpleAssertionBytecode || simpleAssertionBytecode === "0x") {
+      throw new Error("SimpleCounterAssertion artifact bytecode is missing");
+    }
+
+    const simpleAssertionFactory = new ethers.ContractFactory(
+      SimpleCounterAssertionArtifact.abi,
+      simpleAssertionBytecode,
+      managerSigner,
+    );
+    const simpleAssertionDeployRequest = await simpleAssertionFactory.getDeployTransaction(EXPECTED_COUNTER_ADDRESS);
+    const simpleAssertionInitCode = simpleAssertionDeployRequest.data;
+
+    if (!simpleAssertionInitCode || simpleAssertionInitCode === "0x") {
+      throw new Error("SimpleCounterAssertion init code is missing");
+    }
+
+    const { assertionId, signature } = await assertionDaClient.submitAssertionBytecode(simpleAssertionInitCode);
+    latestAssertionId = assertionId;
+    expect(assertionId).toMatch(/^0x[0-9a-fA-F]{64}$/);
+    expect(signature).toMatch(/^0x[0-9a-fA-F]+$/);
+
+    logger.info(
+      `Stored SimpleCounter assertion on DA. assertionId=${assertionId} signatureLength=${(signature.length - 2) / 2}`,
+    );
+
+    const assertionAlreadyTracked = await stateOracleReadonly.hasAssertion(EXPECTED_COUNTER_ADDRESS, assertionId);
+
+    if (!assertionAlreadyTracked) {
+      const addTx = await stateOracle.addAssertion(EXPECTED_COUNTER_ADDRESS, assertionId, "0x", signature);
+      const addReceipt = await addTx.wait();
+      expect(addReceipt?.status).toEqual(1);
+      logger.info(
+        `Assertion approved on-chain. assertionId=${assertionId} txHash=${addTx.hash} blockNumber=${
+          addReceipt?.blockNumber ?? "null"
+        }`,
+      );
+    } else {
+      logger.info(`Assertion ${assertionId} already active for counter ${EXPECTED_COUNTER_ADDRESS}, skipping add.`);
+    }
+
+    const [activationBlock, deactivationBlock] = await stateOracleReadonly.getAssertionWindow(
+      EXPECTED_COUNTER_ADDRESS,
+      assertionId,
+    );
+
+    expect(activationBlock).toBeGreaterThan(0n);
+    expect(deactivationBlock).toEqual(0n);
+
+    logger.info(
+      `Assertion window for counter ${EXPECTED_COUNTER_ADDRESS}. activationBlock=${activationBlock} deactivationBlock=${deactivationBlock}`,
+    );
+  });
+
+  it("allows a single increment but rejects a second one once the assertion is active", async () => {
+    if (!latestAssertionId) {
+      throw new AssertionDaError(
+        "SimpleCounter assertion id not captured. Ensure the registration test ran successfully.",
+      );
+    }
+
+    const logger = global.logger;
+    const l2Provider = config.getL2Provider();
+    const accountManager = config.getL2AccountManager();
+    const incrementSigner = accountManager.whaleAccount(1);
+    const incrementAddress = normalizeAddress(await incrementSigner.getAddress());
+
+    const stateOracleReadonly = new ethers.Contract(STATE_ORACLE_ADDRESS, stateOracleAbi, l2Provider);
+    const [activationBlock] = await stateOracleReadonly.getAssertionWindow(EXPECTED_COUNTER_ADDRESS, latestAssertionId);
+    const activationBlockNumber = Number(activationBlock);
+    const currentBlockNumber = await l2Provider.getBlockNumber();
+
+    if (currentBlockNumber < activationBlockNumber) {
+      logger.info(
+        `Waiting for SimpleCounter assertion activation. activationBlock=${activationBlockNumber} currentBlock=${currentBlockNumber}`,
+      );
+      const hasReachedActivation = await pollForBlockNumber(l2Provider, activationBlockNumber);
+      expect(hasReachedActivation).toBe(true);
+    }
+
+    const counterReadonly = new ethers.Contract(EXPECTED_COUNTER_ADDRESS, CounterArtifact.abi, l2Provider);
+    const counter = counterReadonly.connect(incrementSigner);
+
+    const initialCounterValue = await counterReadonly.number();
+    logger.info(
+      `Attempting counter increments. signer=${incrementAddress} initialValue=${initialCounterValue} assertionId=${latestAssertionId}`,
+    );
+
+    const firstTx = await counter.increment();
+    logger.info(`Submitted first increment transaction. txHash=${firstTx.hash}`);
+    const firstReceipt = await firstTx.wait();
+    expect(firstReceipt?.status).toEqual(1);
+
+    const afterFirstIncrement = await counterReadonly.number();
+    expect(afterFirstIncrement).toEqual(initialCounterValue + 1n);
+
+    const secondTx = await counter.increment();
+    logger.info(`Submitted second increment transaction. txHash=${secondTx.hash}`);
+
+    let secondReceipt: ethers.TransactionReceipt | null = null;
+    let secondErrorMessage: string | null = null;
+
+    try {
+      secondReceipt = await secondTx.wait();
+    } catch (error) {
+      secondErrorMessage = error instanceof Error ? error.message : String(error);
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "receipt" in error &&
+        (error as { receipt?: ethers.TransactionReceipt | null }).receipt
+      ) {
+        secondReceipt = (error as { receipt?: ethers.TransactionReceipt | null }).receipt ?? null;
+      }
+      if (secondErrorMessage) {
+        logger.info(`Second increment failed as expected. signer=${incrementAddress} error=${secondErrorMessage}`);
+      }
+    }
+
+    if (secondReceipt) {
+      expect(secondReceipt.status).not.toEqual(1);
+    } else {
+      expect(secondErrorMessage).toBeTruthy();
+    }
+
+    if (secondErrorMessage) {
+      expect(secondErrorMessage.toLowerCase()).toContain("counter cannot be greater than 1");
+    }
+
+    const finalCounterValue = await counterReadonly.number();
+    expect(finalCounterValue).toEqual(afterFirstIncrement);
   });
 });
 

--- a/e2e/src/credible-layer.spec.ts
+++ b/e2e/src/credible-layer.spec.ts
@@ -1,0 +1,86 @@
+import { beforeAll, describe, expect, it } from "@jest/globals";
+import { config } from "./config/tests-config";
+import { AssertionDaClient, AssertionDaError } from "./common/utils";
+import { STATE_ORACLE_ADDRESS } from "./common/constants";
+
+const assertionDaEndpoint = config.getAssertionDaEndpoint();
+
+// Skip the entire suite when the Credible stack is not running.
+const describeCredible = assertionDaEndpoint ? describe : describe.skip;
+
+describeCredible("Credible layer e2e test suite", () => {
+  let assertionDaClient: AssertionDaClient;
+
+  const knownAssertionId = process.env.CREDIBLE_TEST_ASSERTION_ID;
+  const testAssertionArtifact = process.env.CREDIBLE_ASSERTION_ARTIFACT;
+  const ctorArgsEnv = process.env.CREDIBLE_ASSERTION_CONSTRUCTOR_ARGS;
+  const pclBinaryPath = process.env.CREDIBLE_PCL_PATH ?? "pcl";
+  const pclWorkingDir = process.env.CREDIBLE_ASSERTION_WORKDIR;
+  const parsedTimeout = process.env.CREDIBLE_ASSERTION_TIMEOUT_MS
+    ? Number.parseInt(process.env.CREDIBLE_ASSERTION_TIMEOUT_MS, 10)
+    : undefined;
+  const pclTimeoutMs = Number.isNaN(parsedTimeout) ? undefined : parsedTimeout;
+
+  const constructorArgs = ctorArgsEnv
+    ? ctorArgsEnv
+        .split(",")
+        .map((arg) => arg.trim())
+        .filter(Boolean)
+    : [STATE_ORACLE_ADDRESS];
+
+  beforeAll(() => {
+    if (!assertionDaEndpoint) {
+      throw new AssertionDaError("Assertion DA endpoint not configured");
+    }
+
+    assertionDaClient = new AssertionDaClient(assertionDaEndpoint, pclBinaryPath);
+  });
+
+  const readAssertion = async () => {
+    if (!knownAssertionId) {
+      throw new AssertionDaError("CREDIBLE_TEST_ASSERTION_ID is not configured");
+    }
+
+    expect.assertions(2);
+
+    const assertion = await assertionDaClient.getAssertion(knownAssertionId);
+
+    expect(assertion.bytecode).toBeDefined();
+    expect(assertion.signature).toBeDefined();
+  };
+
+  if (knownAssertionId) {
+    it("reads metadata for an existing assertion", readAssertion);
+  } else {
+    it.skip("reads metadata for an existing assertion", readAssertion);
+  }
+
+  const storeAssertion = async () => {
+    if (!testAssertionArtifact) {
+      throw new AssertionDaError("CREDIBLE_ASSERTION_ARTIFACT is not configured");
+    }
+
+    expect.assertions(2);
+
+    const { assertionId, signature } = await assertionDaClient.storeAssertion(testAssertionArtifact, constructorArgs, {
+      cwd: pclWorkingDir,
+      timeoutMs: pclTimeoutMs,
+    });
+
+    expect(assertionId).toMatch(/^0x[0-9a-fA-F]+$/);
+    expect(signature).toMatch(/^0x[0-9a-fA-F]+$/);
+  };
+
+  if (testAssertionArtifact) {
+    it("stores a new assertion via the PCL CLI", storeAssertion);
+  } else {
+    it.skip("stores a new assertion via the PCL CLI", storeAssertion);
+  }
+
+  it("tracks end-to-end flows between the Credible sidecar and Assertion DA", async () => {
+    // Placeholder for the full Credible flow validation.
+    // TODO: Submit an assertion through the sidecar, wait for it to propagate,
+    // and verify the state oracle contract is updated accordingly.
+    expect(true).toBeTruthy();
+  });
+});


### PR DESCRIPTION
- This PR adds credible layer e2e tests. The flow tests if the credible layer sidecar rejects invalidating transactions or not. It deployes a contract, registers it, sends assertion to the da, and makes sure that assertions trigger when needed.
- Modifies dockercompose/config files to use limitless zktracer configs to prevent gas issues