### PR TITLE
credible-pluigin: bump version to 0.2.1-besu26.4.0

### DIFF
--- a/linea-besu-package/scripts/assemble-credible.sh
+++ b/linea-besu-package/scripts/assemble-credible.sh
@@ -7,7 +7,7 @@ OWNER="phylaxsystems"
 REPO="credible-layer-besu-plugin"
 GROUP_ID="net.phylax.credible"
 ARTIFACT_ID="credible-layer-besu-plugin"
-VERSION="0.3.0-51e93cb0"
+VERSION="0.2.1-besu26.4.0"
 
 OUTPUT_LOC="./linea-besu/besu/plugins/$ARTIFACT_ID-$VERSION.jar"
 


### PR DESCRIPTION
# Description

- credible-pluigin: bump version to 0.2.1-besu26.4.0